### PR TITLE
Preserve baggage items when appending new context data

### DIFF
--- a/baggage.go
+++ b/baggage.go
@@ -13,19 +13,19 @@ func GetBaggage(ctx context.Context) baggage.Baggage {
 
 // AddBaggageItem adds a key-value pair to the baggage.
 func AddBaggageItem(ctx context.Context, key, value string) context.Context {
+	b := baggage.FromContext(ctx)
 	m, _ := baggage.NewMember(key, value)
-	b, _ := baggage.New(m)
+	b, _ = b.SetMember(m)
 	return baggage.ContextWithBaggage(ctx, b)
 }
 
 // AddBaggageItems adds multiple key-value pairs to the baggage.
 func AddBaggageItems(ctx context.Context, items map[string]string) context.Context {
-	var members []baggage.Member
+	b := baggage.FromContext(ctx)
 	for key, value := range items {
 		m, _ := baggage.NewMember(key, value)
-		members = append(members, m)
+		b, _ = b.SetMember(m)
 	}
-	b, _ := baggage.New(members...)
 	return baggage.ContextWithBaggage(ctx, b)
 }
 

--- a/baggage_test.go
+++ b/baggage_test.go
@@ -1,0 +1,29 @@
+package otelemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddBaggageItem(t *testing.T) {
+	ctx := context.Background()
+	ctx = AddBaggageItem(ctx, "user", "alice")
+	ctx = AddBaggageItem(ctx, "tenant", "acme")
+
+	b := GetBaggage(ctx)
+	assert.Equal(t, "alice", b.Member("user").Value())
+	assert.Equal(t, "acme", b.Member("tenant").Value())
+}
+
+func TestAddBaggageItems(t *testing.T) {
+	ctx := context.Background()
+	ctx = AddBaggageItem(ctx, "user", "alice")
+	ctx = AddBaggageItems(ctx, map[string]string{"tenant": "acme", "role": "admin"})
+
+	b := GetBaggage(ctx)
+	assert.Equal(t, "alice", b.Member("user").Value())
+	assert.Equal(t, "acme", b.Member("tenant").Value())
+	assert.Equal(t, "admin", b.Member("role").Value())
+}


### PR DESCRIPTION
## Summary
- ensure `AddBaggageItem` and `AddBaggageItems` merge with existing baggage instead of overwriting
- add tests covering baggage accumulation helpers

## Testing
- `GOPROXY=direct go test ./...` *(fails: unrecognized import paths / network 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6899848cc4f08326bfe88bc0e6e837d2